### PR TITLE
osprey: Set the kernel flags on common

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -29,8 +29,6 @@ TARGET_RECOVERY_DEVICE_MODULES := libinit_osprey
 
 # Kernel
 TARGET_KERNEL_CONFIG := osprey_defconfig
-BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
-TARGET_KERNEL_CROSS_COMPILE_PREFIX := $(PWD)/prebuilts/gcc/linux-x86/arm/arm-eabi-4.8/bin/arm-eabi-
 
 # Partitions
 BOARD_BOOTIMAGE_PARTITION_SIZE := 16777216     # 16384 * 1024 mmcblk0p31


### PR DESCRIPTION
Remove this from here, it's now on common